### PR TITLE
Add mark all as read button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hacker News Top Stories Changelog
 
+## [Add Mark As Read button] - {PR_MERGE_DATE}
+
+Adds an option to mark all stories as read, so the icon will mute until a new story comes in.
+
 ## [Initial Version] - 2025-04-14
 
 Initial version

--- a/src/view-top-stories.tsx
+++ b/src/view-top-stories.tsx
@@ -72,8 +72,6 @@ export default function Command() {
 
   if (cache.get(prefKey) !== points) {
     // if the points have changed, clear the cache
-    // cache.set(readKey, JSON.stringify([]));
-    // cache.set(seenKey, JSON.stringify([]));
     cache.clear();
   }
 
@@ -109,6 +107,18 @@ export default function Command() {
         <MenuItems error={error} stories={stories} setStories={setStories} readStories={readStories} points={points} />
       </MenuBarExtra.Section>
       <MenuBarExtra.Section>
+        <MenuBarExtra.Item
+          title="Mark All As Read"
+          icon={Icon.Checkmark}
+          onAction={() => {
+            stories.forEach(({ external_url }) => {
+              readStories.add(external_url);
+            });
+            cache.set(readKey, JSON.stringify(Array.from(readStories)));
+            // force update the icon
+            setStories((prev) => structuredClone(prev));
+          }}
+        />
         <MenuBarExtra.Item
           title="Open Preferences"
           onAction={openExtensionPreferences}


### PR DESCRIPTION
Adds a button to mark all stories as read

![CleanShot 2025-04-22 at 00 13 30@2x](https://github.com/user-attachments/assets/e984228b-5bb7-458d-9b7b-69a5b733b59c)
